### PR TITLE
Add customizable chunk size for mixed worksheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A modern, web-based Python app for generating customizable math worksheet PDFs. 
 - Select one or more problem types.
 - Optionally adjust the term ranges (defaults are shown and can be reset).
 - Set the number of problems per type.
+- Choose how many problems appear in each section (defaults to 25).
 - Click **Generate** to preview and download the worksheet PDF.
 
 ## API Endpoints
@@ -39,6 +40,7 @@ Generate a worksheet PDF.
   {
     "problem_types": ["multiplication", "addition"],
     "n": 100,
+    "chunk": 25,
     "term1": "2..12",      // optional, single-type only
     "term2": "2..12",      // optional, single-type only
     "defaults": {           // optional per-type overrides
@@ -79,6 +81,7 @@ import requests
 payload = {
     "problem_types": ["multiplication"],
     "n": 50,
+    "chunk": 25,
     "term1": "2..12",
     "term2": "2..12"
 }


### PR DESCRIPTION
## Summary
- allow specifying a `chunk` size for mixed worksheets
- render full page sections when chunk > 25
- expose new option in API and web UI
- document chunk parameter in README

## Testing
- `python -m py_compile main.py worksheet_core.py`

------
https://chatgpt.com/codex/tasks/task_e_68653cf34bcc832ea4ef1394c8365006